### PR TITLE
fix controllers and views path with backslashes

### DIFF
--- a/Command/GenerateCommand.php
+++ b/Command/GenerateCommand.php
@@ -108,7 +108,8 @@ class GenerateCommand extends GeneratorCommand
             try {
                 $b = $this->getContainer()->get('kernel')->getBundle($bundle);
 
-                if (!file_exists($b->getPath().'/Controller/'.$controller.'Controller.php')) {
+                $controllerPath = str_replace('\\', '/', $controller);
+                if (!file_exists($b->getPath().'/Controller/'.$controllerPath.'Controller.php')) {
                     break;
                 }
 
@@ -125,7 +126,7 @@ class GenerateCommand extends GeneratorCommand
             array(
                 '',
                 'Determine the entity name.',
-                'ex: AppBundle/MyEntity',
+                'ex: AppBundle:MyEntity',
                 '',
             )
         );

--- a/Generator/ControllerGenerator.php
+++ b/Generator/ControllerGenerator.php
@@ -31,13 +31,15 @@ class ControllerGenerator extends Generator
             $fields[$field] = $type;
         }
 
+        // fix slashes
+        $controller = str_replace('\\', '/', $controller);
         $dir = $bundle->getPath();
         $controllerFile = $dir.'/Controller/'.$controller.'Controller.php';
         if (file_exists($controllerFile)) {
             throw new \RuntimeException(sprintf('Controller "%s" already exists', $controller));
         }
-        $templateList=$dir.'/Resources/views/'.$controller.'/list.html.twig';
-        $templateListAjax=$dir.'/Resources/views/'.$controller.'/_list.html.twig';
+        $templateList = $dir.'/Resources/views/'.$controller.'/list.html.twig';
+        $templateListAjax = $dir.'/Resources/views/'.$controller.'/_list.html.twig';
 
         $parameters = array(
             'namespace' => $bundle->getNamespace(),


### PR DESCRIPTION
Fixed !

```shell
                         
  Controller generation  
                         

  created ./vendor/sfk/framework-bundle/Controller/Admin/User/AgencyController.php
  created ./vendor/sfk/framework-bundle/Resources/views/Admin/User/Agency/
  created ./vendor/sfk/framework-bundle/Resources/views/Admin/User/Agency/list.html.twig
  created ./vendor/sfk/framework-bundle/Resources/views/Admin/User/Agency/_list.html.twig
Generating the bundle code: OK

                                         
  Everything is OK! Now get to work :).  

```