### PR TITLE
Ask for reload on filter change

### DIFF
--- a/Resources/public/js/KilikTable.js
+++ b/Resources/public/js/KilikTable.js
@@ -99,7 +99,7 @@ function KilikTable(id, path, options) {
 
         // filtering
         $("form[name='" + this.getFormName() + "']").find(".refreshOnChange").change(function () {
-            table.doReload();
+            table.askForReload();
         });
         $("form[name='" + this.getFormName() + "']").find(".refreshOnKeyup").keyup(function () {
             // delayed reload


### PR DESCRIPTION
When a key is pressed : a reload is asked.
If you have a link/button in your rows : by clicking on it, a change event is fired from the filter field left.
And if the ajax response is really fast : the refresh will prevents the click from working.

Adding an askForReload give the same behavior to change and keyup events.