### PR TITLE
Allow autowiring out of the box

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -9,3 +9,5 @@ services:
         arguments:    ["@twig","@form.factory"]
         public: true
 
+    Kilik\TableBundle\Services\TableService: '@kilik_table'
+    Kilik\TableBundle\Services\TableApiService: 'kilik_table_api'


### PR DESCRIPTION
This modification allow to directly use autowiring without having to define an alias in the project