### PR TITLE
WIP - Fix rows count when using Doctrine custom output walker

### DIFF
--- a/src/Services/TableService.php
+++ b/src/Services/TableService.php
@@ -153,6 +153,7 @@ class TableService extends AbstractTableService
 
         if (is_null($identifiers)) {
             $paginatorTotal = new Paginator($qbtr->getQuery());
+            $paginatorTotal->setUseOutputWalkers(true);
             $count = $paginatorTotal->count();
         } else {
             $qbtr->select($qbtr->expr()->count($identifiers));
@@ -178,6 +179,7 @@ class TableService extends AbstractTableService
 
         if (is_null($identifiers)) {
             $paginatorFiltered = new Paginator($qbfr->getQuery());
+            $paginatorFiltered->setUseOutputWalkers(true);
             $count = $paginatorFiltered->count();
         } else {
             $qbfr->select($qbfr->expr()->count($identifiers));


### PR DESCRIPTION
Issue prerequisites :
- Using custom output walker (Eg. to transform LIKE to ILIKE on postgresql) : \Doctrine\ORM\Configuration::setDefaultQueryHint
- Table query builder use an having filter

When filtering on column using having filter, an expection "Cannot count query that uses a HAVING clause. Use the output walkers for pagination" is thrown.
Because \Doctrine\ORM\Tools\Pagination\Paginator::getCountQuery checks if HINT_CUSTOM_OUTPUT_WALKER is defined for applying CountOutputWalker.