### PR TITLE
Allow inputBag non-scalar values in getSelectedRows

### DIFF
--- a/src/Services/AbstractTableService.php
+++ b/src/Services/AbstractTableService.php
@@ -190,7 +190,7 @@ abstract class AbstractTableService implements TableServiceInterface
      */
     public function getSelectedRows(Request $request, TableInterface $table)
     {
-        $identifiers = $request->request->get($table->getSelectionFormKey());
+        $identifiers = $request->request->all($table->getSelectionFormKey());
         $entities = $this->loadRowsById($table, $identifiers);
 
         return $entities;


### PR DESCRIPTION
Fix "Input value contains a non-scalar value" error when trying to get table selected rows due to Symfony 6 InputBag deprecating retrieving non-scalar values. Using all($key)" instead as it's recommended now [#41766 (comment)](https://github.com/symfony/symfony/pull/41766#issuecomment-865083005)