### PR TITLE
Filter date properly

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,33 @@
+<?php
+
+$finder = (new PhpCsFixer\Finder())
+    ->in(['src/', 'tests/'])
+;
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        'combine_consecutive_unsets' => true,
+        'no_superfluous_phpdoc_tags' => true,
+        'phpdoc_separation' => false,
+        'phpdoc_types_order' => false,
+        'native_function_invocation' => false,
+        'single_line_throw' => false,
+        'heredoc_to_nowdoc' => true,
+        'no_extra_blank_lines' => ['tokens' => [
+            'break', 'continue', 'extra', 'return', 'throw', 'use',
+            'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block',
+        ]],
+        'no_unreachable_default_argument_value' => true,
+        'no_useless_else' => true,
+        'no_useless_return' => true,
+        'ordered_class_elements' => true,
+        'ordered_imports' => true,
+        'phpdoc_order' => true,
+        'psr_autoloading' => true,
+    ])
+    ->setUsingCache(false)
+    ->setRiskyAllowed(true)
+    ->setFinder($finder)
+;

--- a/README.md
+++ b/README.md
@@ -262,6 +262,35 @@ When a filter is filled, class <em>table-filter-filled</em> is added on field. B
 }
 ```
 
+### Filter date columns
+
+```php
+$table
+    ->addColumn(
+        (new Column())
+            ->setSort(['u.createdAt' => 'asc'])
+            ->setDisplayFormat(Column::FORMAT_DATE)
+            ->setDisplayFormatParams('d/m/Y H:i:s') // or for example FilterDate::INPUT_FORMAT_LITTLE_ENDIAN
+            ->setFilter((new FilterDate())
+                ->setName('u_createdAt')
+                ->setField('u.createdAt')
+                ->setInputFormat(FilterDate::INPUT_FORMAT_LITTLE_ENDIAN)
+            )
+    )
+;
+```
+
+Users can filter this data using various operators, for example :
+- `26/02/1802` or `=26/02/1802` : expects a specific day
+- `!=21/11/1694` : expects any day except 21 November 1694
+- `>26/02/1802 18:00` : expects specific day after 18:00 and without end limit
+- `>=02/1802` : expects in february 1802 and after
+- `<2024` : expects in 2023 and before
+- `<=26/02/1802 15` : expects 26 February 1802 at 3pm or earlier
+- `=` : expects date is NULL
+- `!=` : expects date is not NULL
+
+
 For bundle developpers
 ======================
 

--- a/src/Components/Filter.php
+++ b/src/Components/Filter.php
@@ -106,7 +106,7 @@ class Filter
      *
      * @var string
      */
-    private $type = self::TYPE_DEFAULT;
+    protected $type = self::TYPE_DEFAULT;
 
     /**
      * Data format.

--- a/src/Components/Filter.php
+++ b/src/Components/Filter.php
@@ -195,7 +195,7 @@ class Filter
      */
     public function setType($type)
     {
-        if (!in_array($type, self::TYPES)) {
+        if (!in_array($type, static::TYPES)) {
             throw new \InvalidArgumentException("bad type {$type}");
         }
         $this->type = $type;

--- a/src/Components/FilterDate.php
+++ b/src/Components/FilterDate.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Kilik\TableBundle\Components;
+
+use Doctrine\ORM\QueryBuilder;
+
+class FilterDate extends Filter
+{
+    public const INPUT_FORMAT_BIG_ENDIAN = 'Y-m-d H:i:s'; // Accepts also input with "/" : Y/m/d H:i:s
+    public const INPUT_FORMAT_LITTLE_ENDIAN = 'd-m-Y H:i:s';  // Accepts also input with "/" : d/m/Y H:i:s
+
+    public const INPUT_FORMATS = [
+        self::INPUT_FORMAT_BIG_ENDIAN,
+        self::INPUT_FORMAT_LITTLE_ENDIAN,
+    ];
+
+    public const TYPES = [
+        self::TYPE_EQUAL, // `=2014-07-27` expects BETWEEN 2014-07-27 00:00:00 AND 2014-07-27 23:59:59
+        self::TYPE_NOT_EQUAL, // `!=2014-07-27` expects NOT BETWEEN 2014-07-27 00:00:00 AND 2014-07-27 23:59:59
+        self::TYPE_GREATER, // `>2014-07-27` expects > 2014-07-27 23:59:59
+        self::TYPE_GREATER_OR_EQUAL, // `>=2014-07-27` expects >= 2014-07-27 00:00:00
+        self::TYPE_LESS, // `<2014-07-27` expects < 2014-07-27 00:00:00
+        self::TYPE_LESS_OR_EQUAL, // `<=2014-07-27` expects < 2014-07-27 23:59:59
+    ];
+
+    protected string $inputFormat = self::INPUT_FORMAT_BIG_ENDIAN;
+
+    public function __construct()
+    {
+        $this->setQueryPartBuilder(function (Filter $filter, Table $table, QueryBuilder $qb, $rawInput) {
+            $rawInput = trim((string) $rawInput);
+            if ('' === $rawInput) {
+                return;
+            }
+
+            list($operator, $input) = $this->getOperatorAndValue($rawInput);
+            if ('' === (string) $input) {
+                switch ($operator) {
+                    case static::TYPE_EQUAL:
+                        $qb->andWhere($this->getField().' IS NULL');
+
+                        return;
+                    case static::TYPE_NOT_EQUAL:
+                        $qb->andWhere($this->getField().' IS NOT NULL');
+
+                        return;
+                }
+            }
+            if (!in_array($operator, static::TYPES)) {
+                $operator = static::TYPE_EQUAL;
+            }
+
+            if (null === $period = $this->getPeriodFromInput($input)) {
+                $qb->andWhere('0=1');
+
+                return;
+            }
+
+            $query = $this->buildWhereQuery($operator);
+            if (false !== strpos($query, $this->buildPeriodStartParameterName())) {
+                $qb->setParameter($this->buildPeriodStartParameterName(), $period[0]);
+            }
+            if (false !== strpos($query, $this->buildPeriodEndParameterName())) {
+                $qb->setParameter($this->buildPeriodEndParameterName(), $period[1]);
+            }
+
+            $qb->andWhere($query);
+        });
+    }
+
+    public function setDataFormat($dataFormat)
+    {
+        throw new \LogicException('FilterDate data format cannot be modified.');
+    }
+
+    public function setInputFormatter($formatter)
+    {
+        throw new \LogicException('FilterDate input formatter cannot be modified.');
+    }
+
+    public function getInputFormat(): string
+    {
+        return $this->inputFormat;
+    }
+
+    public function setInputFormat(string $inputFormat): self
+    {
+        if (!in_array($inputFormat, static::INPUT_FORMATS)) {
+            throw new \InvalidArgumentException('Unexpected input format');
+        }
+        $this->inputFormat = $inputFormat;
+
+        return $this;
+    }
+
+    protected function getPeriodFromInput(string $input): ?array
+    {
+        $input = trim(str_replace('/', '-', $input));
+        $format = $this->inputFormat;
+
+        // Complete datetime
+        if (false !== $date = date_create_immutable_from_format($format, $input)) {
+            return $date->getLastErrors() ? null : [$date, $date];
+        }
+
+        // Without second
+        $format = trim(str_replace('s', '', $format), '-: ');
+        if (false !== $date = date_create_immutable_from_format('!'.$format, $input)) {
+            return $date->getLastErrors() ? null : [$date, $date->modify('+59 seconds')];
+        }
+
+        // Without minute
+        $format = trim(str_replace('i', '', $format), '-: ');
+        if (false !== $date = date_create_immutable_from_format('!'.$format, $input)) {
+            return $date->getLastErrors() ? null : [$date, $date->modify('+1 hour -1 second')];
+        }
+
+        // Only date (without time)
+        $format = trim(str_replace('H', '', $format), '-: ');
+        if (false !== $date = date_create_immutable_from_format('!'.$format, $input)) {
+            return $date->getLastErrors() ? null : [$date, $date->modify('+1 day -1 second')];
+        }
+
+        // Only month and year
+        $format = trim(str_replace('d', '', $format), '-: ');
+        if (false !== $date = date_create_immutable_from_format('!'.$format, $input)) {
+            return $date->getLastErrors() ? null : [$date, $date->modify('+1 month -1 second')];
+        }
+
+        // Only year
+        $format = trim(str_replace('m', '', $format), '-: ');
+        if (false !== $date = date_create_immutable_from_format('!'.$format, $input)) {
+            return $date->getLastErrors() ? null : [$date, $date->modify('+1 year -1 second')];
+        }
+
+        return null;
+    }
+
+    protected function buildWhereQuery(string $operator): string
+    {
+        switch ($operator) {
+            case static::TYPE_NOT_EQUAL:
+                return $this->getField().' NOT BETWEEN :'.$this->buildPeriodStartParameterName().' AND :'.$this->buildPeriodEndParameterName();
+            case static::TYPE_GREATER:
+                return $this->getField().' > :'.$this->buildPeriodEndParameterName();
+            case static::TYPE_GREATER_OR_EQUAL:
+                return $this->getField().' >= :'.$this->buildPeriodStartParameterName();
+            case static::TYPE_LESS:
+                return $this->getField().' < :'.$this->buildPeriodStartParameterName();
+            case static::TYPE_LESS_OR_EQUAL:
+                return $this->getField().' <= :'.$this->buildPeriodEndParameterName();
+            default:
+            case static::TYPE_EQUAL:
+                return $this->getField().' BETWEEN :'.$this->buildPeriodStartParameterName().' AND :'.$this->buildPeriodEndParameterName();
+        }
+    }
+
+    protected function buildPeriodStartParameterName(): string
+    {
+        return 'filter_'.$this->getName().'_start';
+    }
+
+    protected function buildPeriodEndParameterName(): string
+    {
+        return 'filter_'.$this->getName().'_end';
+    }
+}

--- a/src/Components/FilterSelect.php
+++ b/src/Components/FilterSelect.php
@@ -11,6 +11,8 @@ class FilterSelect extends Filter
      */
     protected $input = ChoiceType::class;
 
+    protected $type = self::TYPE_EQUAL_STRICT;
+
     /**
      * Liste des valeurs du select.
      *
@@ -227,7 +229,7 @@ class FilterSelect extends Filter
     public function getOptions()
     {
         $options = array_merge(
-            array(
+            [
                 'required' => false,
                 'choices' => $this->getChoices(),
                 'placeholder' => $this->getPlaceholder(),
@@ -236,7 +238,7 @@ class FilterSelect extends Filter
                 'choice_value' => $this->getChoiceValue(),
                 'translation_domain' => $this->getTranslationDomain(),
                 'choice_translation_domain' => $this->getChoiceTranslationDomain(),
-            ),
+            ],
             $this->options
         );
 

--- a/tests/Components/FilterDateTest.php
+++ b/tests/Components/FilterDateTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Components;
+
+use Doctrine\ORM\QueryBuilder;
+use Kilik\TableBundle\Components\FilterDate;
+use Kilik\TableBundle\Components\Table;
+use PHPUnit\Framework\MockObject\Rule\InvokedCount;
+use PHPUnit\Framework\TestCase;
+
+class FilterDateTest extends TestCase
+{
+    public function testGetPeriodFromInput()
+    {
+        $assertPeriodFromInput = function (FilterDate $filter, string $input, string $expectedStart, string $expectedEnd) {
+            static $class, $method;
+            if (null === $class) {
+                $class = new \ReflectionClass(FilterDate::class);
+                $method = $class->getMethod('getPeriodFromInput');
+                $method->setAccessible(true);
+            }
+
+            $result = $method->invoke($filter, $input);
+            $this->assertEquals($result[0], date_create_immutable($expectedStart));
+            $this->assertEquals($result[1], date_create_immutable($expectedEnd));
+        };
+
+        $filter = (new FilterDate())->setInputFormat(FilterDate::INPUT_FORMAT_BIG_ENDIAN);
+        $assertPeriodFromInput($filter, '1802-02-26 10:25:26', '1802-02-26 10:25:26', '1802-02-26 10:25:26');
+        $assertPeriodFromInput($filter, '1802-02-26 10:25 ', '1802-02-26 10:25:00', '1802-02-26 10:25:59');
+        $assertPeriodFromInput($filter, ' 1802-02-26 10', '1802-02-26 10:00:00', '1802-02-26 10:59:59');
+        $assertPeriodFromInput($filter, ' 1802-02-26  ', '1802-02-26 00:00:00', '1802-02-26 23:59:59');
+        $assertPeriodFromInput($filter, ' 1804-02', '1804-02-01 00:00:00', '1804-02-29 23:59:59');
+        $assertPeriodFromInput($filter, ' 1989', '1989-01-01 00:00:00', '1989-12-31 23:59:59');
+        $assertPeriodFromInput($filter, '2089-07-21 21:00:22', '2089-07-21 21:00:22', '2089-07-21 21:00:22');
+        $assertPeriodFromInput($filter, '2089-07-21 15:00', '2089-07-21 15:00:00', '2089-07-21 15:00:59');
+        $assertPeriodFromInput($filter, '2089-07-21 13', '2089-07-21 13:00:00', '2089-07-21 13:59:59');
+        $assertPeriodFromInput($filter, '2089-07-21', '2089-07-21 00:00:00', '2089-07-21 23:59:59');
+        $assertPeriodFromInput($filter, '2089-07', '2089-07-01 00:00:00', '2089-07-31 23:59:59');
+        $assertPeriodFromInput($filter, '2089', '2089-01-01 00:00:00', '2089-12-31 23:59:59');
+
+        $filter = (new FilterDate())->setInputFormat(FilterDate::INPUT_FORMAT_LITTLE_ENDIAN);
+        $assertPeriodFromInput($filter, '21/11/1694 10:25:26', '1694-11-21 10:25:26', '1694-11-21 10:25:26');
+        $assertPeriodFromInput($filter, '21/11/1694 10:25 ', '1694-11-21 10:25:00', '1694-11-21 10:25:59');
+        $assertPeriodFromInput($filter, ' 21-11-1694 10', '1694-11-21 10:00:00', '1694-11-21 10:59:59');
+        $assertPeriodFromInput($filter, ' 21/11/1694  ', '1694-11-21 00:00:00', '1694-11-21 23:59:59');
+        $assertPeriodFromInput($filter, ' 11-1694', '1694-11-01 00:00:00', '1694-11-30 23:59:59');
+        $assertPeriodFromInput($filter, ' 1517', '1517-01-01 00:00:00', '1517-12-31 23:59:59');
+        $assertPeriodFromInput($filter, '23/01/2091 09:43:22', '2091-01-23 09:43:22', '2091-01-23 09:43:22');
+        $assertPeriodFromInput($filter, '23-01-2091 09:43', '2091-01-23 09:43:00', '2091-01-23 09:43:59');
+        $assertPeriodFromInput($filter, '23/01/2091 09', '2091-01-23 09:00:00', '2091-01-23 09:59:59');
+        $assertPeriodFromInput($filter, '23/01/2091', '2091-01-23 00:00:00', '2091-01-23 23:59:59');
+        $assertPeriodFromInput($filter, '01-2091', '2091-01-01 00:00:00', '2091-01-31 23:59:59');
+        $assertPeriodFromInput($filter, '2091', '2091-01-01 00:00:00', '2091-12-31 23:59:59');
+    }
+
+    public function testGetPeriodFromInvalidInput()
+    {
+        $class = new \ReflectionClass(FilterDate::class);
+        $method = $class->getMethod('getPeriodFromInput');
+        $method->setAccessible(true);
+
+        $filter = (new FilterDate())->setInputFormat(FilterDate::INPUT_FORMAT_BIG_ENDIAN);
+        $this->assertNull($method->invoke($filter, '2024ZZ'));
+        $this->assertNull($method->invoke($filter, '2023-02-29'));
+        $this->assertNull($method->invoke($filter, '2024-02-30'));
+        $this->assertNull($method->invoke($filter, '2024/28/02'));
+        $this->assertNull($method->invoke($filter, '2024-02-28 26:00:00'));
+        $this->assertNull($method->invoke($filter, '2024-02-28 12:65:00'));
+        $this->assertNull($method->invoke($filter, '23/01/1991 09:00:00'));
+        $this->assertNull($method->invoke($filter, 'Murs, ville, Et port. Asile De mort,'));
+
+        $filter = (new FilterDate())->setInputFormat(FilterDate::INPUT_FORMAT_LITTLE_ENDIAN);
+        $this->assertNull($method->invoke($filter, '202A'));
+        $this->assertNull($method->invoke($filter, '29/02/2023'));
+        $this->assertNull($method->invoke($filter, '30/02/2024'));
+        $this->assertNull($method->invoke($filter, '02-28-2024'));
+        $this->assertNull($method->invoke($filter, '28/02/2024 24:29:59'));
+        $this->assertNull($method->invoke($filter, '28/02/2024 09:00:68'));
+        $this->assertNull($method->invoke($filter, '1991-01-23'));
+        $this->assertNull($method->invoke($filter, 'Mer grise Où brise La brise, Tout dort.'));
+    }
+
+    public function testBuildWhereQuery()
+    {
+        $assertQuery = function (FilterDate $filter, string $operator, string $expected) {
+            static $class, $method;
+            if (null === $class) {
+                $class = new \ReflectionClass(FilterDate::class);
+                $method = $class->getMethod('buildWhereQuery');
+                $method->setAccessible(true);
+            }
+
+            $result = $method->invoke($filter, $operator);
+            $this->assertEquals($result, $expected);
+        };
+
+        $filter = (new FilterDate())->setName('zz')->setField('f.createdAt');
+        $assertQuery($filter, '', 'f.createdAt BETWEEN :filter_zz_start AND :filter_zz_end');
+        $assertQuery($filter, FilterDate::TYPE_EQUAL, 'f.createdAt BETWEEN :filter_zz_start AND :filter_zz_end');
+        $assertQuery($filter, FilterDate::TYPE_NOT_EQUAL, 'f.createdAt NOT BETWEEN :filter_zz_start AND :filter_zz_end');
+        $assertQuery($filter, FilterDate::TYPE_GREATER, 'f.createdAt > :filter_zz_end');
+        $assertQuery($filter, FilterDate::TYPE_GREATER_OR_EQUAL, 'f.createdAt >= :filter_zz_start');
+        $assertQuery($filter, FilterDate::TYPE_LESS, 'f.createdAt < :filter_zz_start');
+        $assertQuery($filter, FilterDate::TYPE_LESS_OR_EQUAL, 'f.createdAt <= :filter_zz_end');
+    }
+
+    public function testQueryPartBuilder()
+    {
+        $assert = function (FilterDate $filter, string $input, string $expectedQuery, array $expectedParameters) {
+            $qb = $this->getMockBuilder(QueryBuilder::class)->disableOriginalConstructor()->getMock();
+            $qb->expects($this->once())->method('andWhere')->with($this->equalTo($expectedQuery));
+
+            $consecutiveParameters = [];
+            foreach ($expectedParameters as $key => $rawDate) {
+                $consecutiveParameters[] = [$key, date_create_immutable($rawDate)];
+            }
+
+            $qb->expects(new InvokedCount(count($expectedParameters)))->method('setParameter')->withConsecutive(...$consecutiveParameters);
+            $filter->getQueryPartBuilder()($filter, new Table(), $qb, $input);
+        };
+
+        $filter = (new FilterDate())->setInputFormat(FilterDate::INPUT_FORMAT_BIG_ENDIAN)->setName('zz')->setField('yy');
+        $assert($filter, '2024-02-28', 'yy BETWEEN :filter_zz_start AND :filter_zz_end', ['filter_zz_start' => '2024-02-28 00:00:00', 'filter_zz_end' => '2024-02-28 23:59:59']);
+        $assert($filter, '=2024-01-31', 'yy BETWEEN :filter_zz_start AND :filter_zz_end', ['filter_zz_start' => '2024-01-31 00:00:00', 'filter_zz_end' => '2024-01-31 23:59:59']);
+        $assert($filter, '!=2024-01-31', 'yy NOT BETWEEN :filter_zz_start AND :filter_zz_end', ['filter_zz_start' => '2024-01-31 00:00:00', 'filter_zz_end' => '2024-01-31 23:59:59']);
+        $assert($filter, '>2024-01-31', 'yy > :filter_zz_end', ['filter_zz_end' => '2024-01-31 23:59:59']);
+        $assert($filter, '>=2024-01-31', 'yy >= :filter_zz_start', ['filter_zz_start' => '2024-01-31 00:00:00']);
+        $assert($filter, '<2024-01-31', 'yy < :filter_zz_start', ['filter_zz_start' => '2024-01-31 00:00:00']);
+        $assert($filter, '<=2024-01-31', 'yy <= :filter_zz_end', ['filter_zz_end' => '2024-01-31 23:59:59']);
+        $assert($filter, '<=20240131', '0=1', []);
+        $assert($filter, '=djobi', '0=1', []);
+        $assert($filter, '=', 'yy IS NULL', []);
+        $assert($filter, '!=', 'yy IS NOT NULL', []);
+
+        $filter = (new FilterDate())->setInputFormat(FilterDate::INPUT_FORMAT_LITTLE_ENDIAN)->setName('zz')->setField('yy');
+        $assert($filter, '28-02-2024', 'yy BETWEEN :filter_zz_start AND :filter_zz_end', ['filter_zz_start' => '2024-02-28 00:00:00', 'filter_zz_end' => '2024-02-28 23:59:59']);
+        $assert($filter, '=31-01-2024', 'yy BETWEEN :filter_zz_start AND :filter_zz_end', ['filter_zz_start' => '2024-01-31 00:00:00', 'filter_zz_end' => '2024-01-31 23:59:59']);
+        $assert($filter, '!=31-01-2024', 'yy NOT BETWEEN :filter_zz_start AND :filter_zz_end', ['filter_zz_start' => '2024-01-31 00:00:00', 'filter_zz_end' => '2024-01-31 23:59:59']);
+        $assert($filter, '>31-01-2024', 'yy > :filter_zz_end', ['filter_zz_end' => '2024-01-31 23:59:59']);
+        $assert($filter, '>=31-01-2024', 'yy >= :filter_zz_start', ['filter_zz_start' => '2024-01-31 00:00:00']);
+        $assert($filter, '<31-01-2024', 'yy < :filter_zz_start', ['filter_zz_start' => '2024-01-31 00:00:00']);
+        $assert($filter, '<=31-01-2024', 'yy <= :filter_zz_end', ['filter_zz_end' => '2024-01-31 23:59:59']);
+        $assert($filter, '>31012024', '0=1', []);
+        $assert($filter, '!=djoba', '0=1', []);
+        $assert($filter, '=', 'yy IS NULL', []);
+        $assert($filter, '!=', 'yy IS NOT NULL', []);
+    }
+}


### PR DESCRIPTION
Legacy Filter with FORMAT_DATE uses a LIKE comparison
which is optimised neither for MySQL nor PgSQL (using TO_CHAR())

I'm taking this opportunity to clarify the code (handling further date formats),
and to make it more consistent for comparisons.